### PR TITLE
Replaced the os.environ.clear by less invasive procedure

### DIFF
--- a/numpy/core/__init__.py
+++ b/numpy/core/__init__.py
@@ -6,15 +6,16 @@ from numpy.version import version as __version__
 # disables OpenBLAS affinity setting of the main thread that limits
 # python threads or processes to one core
 import os
-envbak = os.environ.copy()
-if 'OPENBLAS_MAIN_FREE' not in os.environ:
-    os.environ['OPENBLAS_MAIN_FREE'] = '1'
-if 'GOTOBLAS_MAIN_FREE' not in os.environ:
-    os.environ['GOTOBLAS_MAIN_FREE'] = '1'
+env_added = []
+for envkey in ['OPENBLAS_MAIN_FREE', 'GOTOBLAS_MAIN_FREE']:
+    if envkey not in os.environ:
+        os.environ[envkey] = '1'
+        env_added.append(envkey)
 from . import multiarray
-os.environ.clear()
-os.environ.update(envbak)
-del envbak
+for envkey in env_added:
+    del os.environ[envkey]
+del envkey
+del env_added
 del os
 
 from . import umath


### PR DESCRIPTION
This is mainly a workaround for bug https://bugs.python.org/issue20658 which lets the numpy initialization fail at the os.environ.clear call if the environment contains unusual keys. I also think it is generally a good idea to keep os.environ modifications to a minimum.